### PR TITLE
MaterialEditText v2.1.4をピクトリンクプロジェクトで使用できるよう修正

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,7 +19,7 @@ android {
 dependencies {
   compile 'com.android.support:support-annotations:22.2.0'
   compile 'com.nineoldandroids:library:2.4.0'
-  compile 'com.android.support:appcompat-v7:22.2.0'
+  compile 'com.android.support:appcompat-v7:22.1.1'
 }
 
 // Used to push in maven

--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -1332,7 +1332,7 @@ public class MaterialEditText extends AppCompatEditText {
     float bottomTextPadding = bottomTextSize + textMetrics.ascent + textMetrics.descent;
 
     // draw the characters counter
-    if ((hasFocus() && hasCharactersCounter()) || !isCharactersCountValid()) {
+    if ((/**hasFocus() &&*/ hasCharactersCounter()) || !isCharactersCountValid()) {
       textPaint.setColor(isCharactersCountValid() ? (baseColor & 0x00ffffff | 0x44000000) : errorColor);
       String charactersCounterText = getCharactersCounterText();
       canvas.drawText(charactersCounterText, isRTL() ? startX : endX - textPaint.measureText(charactersCounterText), lineStartY + bottomSpacing + relativeHeight, textPaint);


### PR DESCRIPTION
JIRA: http://jira.local.furyu.jp/browse/FORTUNE-1313
- 文字数カウンターを入力フォームにフォーカスが当たっていなくても表示する
- AndroidAnnotations 3.3.1でビルドが実行できるようappcompat-v7ライブラリのバージョンを22.2.0 -> 22.1.1に下げます。
